### PR TITLE
Automatically disable JQ

### DIFF
--- a/extension/src/viewer/App.tsx
+++ b/extension/src/viewer/App.tsx
@@ -39,7 +39,11 @@ export function App({ jsonText, jqWasmFile }: AppProps): JSX.Element {
 
   // parse json
   const jsonResult = useMemo(() => Json.tryParse(jsonText), [jsonText]);
-  const jqResult = useJQ(jqWasmFile, jsonText, jqCommandState.value);
+  const [jqEnabled, jqResult] = useJQ(
+    jqWasmFile,
+    jsonText,
+    jqCommandState.value
+  );
 
   // fatal error page
   if (jsonResult instanceof Error) {
@@ -55,10 +59,10 @@ export function App({ jsonText, jqWasmFile }: AppProps): JSX.Element {
   const [json, error] = resolveJson(jsonResult, jqResult);
 
   const toolbarProps = {
+    json: json,
     viewerModeState: viewerModeState,
     searchState: searchState,
-    jqCommandState: jqCommandState,
-    json: json,
+    jqCommandState: jqEnabled ? jqCommandState : undefined,
   };
 
   const Viewer =

--- a/extension/src/viewer/components/Toolbar/Toolbar.tsx
+++ b/extension/src/viewer/components/Toolbar/Toolbar.tsx
@@ -12,17 +12,17 @@ import { SearchBox } from "./SearchBox";
 import { ViewerModeToggle } from "./ViewerModeToggle";
 
 export type ToolbarProps = Props<{
+  json: Json.Root;
   viewerModeState: StateObject<ViewerMode>;
   searchState: StateObject<Search>;
-  jqCommandState: StateObject<JQCommand>;
-  json: Json.Root;
+  jqCommandState?: StateObject<JQCommand>;
 }>;
 
 export function Toolbar({
+  json,
   viewerModeState,
   searchState,
   jqCommandState,
-  json,
   className,
 }: ToolbarProps): JSX.Element {
   const t = useContext(TranslationContext);
@@ -35,7 +35,7 @@ export function Toolbar({
         className
       )}
     >
-      <div className="flex items-center mb-0.5">
+      <div className="flex items-center">
         <ViewerModeToggle
           className="w-14 h-7 ml-1"
           viewerMode={viewerModeState.value}
@@ -70,12 +70,14 @@ export function Toolbar({
         />
       </div>
 
-      <div>
-        <JQCommandBox
-          command={jqCommandState.value}
-          setCommand={jqCommandState.setValue}
-        />
-      </div>
+      {jqCommandState && (
+        <div className="pt-0.5">
+          <JQCommandBox
+            command={jqCommandState.value}
+            setCommand={jqCommandState.setValue}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/extension/src/viewer/hooks/UseJQ.ts
+++ b/extension/src/viewer/hooks/UseJQ.ts
@@ -1,16 +1,38 @@
 import { useState } from "react";
-import newJQ from "vendor/jq.wasm";
+import newJQ, { JQ } from "vendor/jq.wasm";
 import * as Json from "viewer/commons/Json";
 import { JQCommand } from "viewer/state";
 import { Mutex, useEffectAsync } from ".";
 
+export type JQEnabled = boolean;
 export type JQResult = Json.Root | Error | undefined;
 
 export function useJQ(
   jqWasmFile: string,
   jsonText: string,
   { filter }: JQCommand
-): JQResult {
+): [JQEnabled, JQResult] {
+  // check if wasm is enabled on first load
+  const [jqEnabled, setJQEnabled] = useState<boolean>(true);
+
+  useEffectAsync(
+    async (mutex: Mutex) => {
+      try {
+        await loadJQ(jqWasmFile);
+        if (mutex.hasLock()) setJQEnabled(true);
+      } catch (e) {
+        if (mutex.hasLock()) {
+          console.warn(
+            "Unable to load JQ, Wasm is probably disabled due to CSP. For additional info: https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md"
+          );
+          setJQEnabled(false);
+        }
+      }
+    },
+    [jqWasmFile, setJQEnabled]
+  );
+
+  // execute command and parse result
   const [result, setResult] = useState<JQResult>(undefined);
 
   useEffectAsync(
@@ -19,22 +41,34 @@ export function useJQ(
         return;
       }
 
-      if (!filter || filter === ".") {
+      if (!jqEnabled || !filter || filter === ".") {
         setResult(undefined);
         return;
       }
 
       try {
-        const module = { locateFile: () => jqWasmFile, noExitRuntime: false };
-        const jq = await newJQ(module);
+        const jq = await loadJQ(jqWasmFile);
         const result = await jq.invoke(jsonText, filter);
         if (mutex.hasLock()) setResult(Json.tryParse(result));
       } catch (e) {
         if (mutex.hasLock()) setResult(e as Error);
       }
     },
-    [jqWasmFile, jsonText, filter, setResult]
+    [jqEnabled, jqWasmFile, jsonText, filter, setResult]
   );
 
-  return result;
+  return [jqEnabled, result];
+}
+
+function loadJQ(jqWasmFile: string): Promise<JQ> {
+  return newJQ({
+    locateFile: () => jqWasmFile,
+    print: devNull,
+    printErr: devNull,
+    noExitRuntime: false,
+  });
+}
+
+function devNull(_message: string) {
+  // do nothing
 }


### PR DESCRIPTION
Try to load JQ wasm on page load and disable the feature in case of failure.

Wasm execution depends on website CSP even if the wasm file is bundled with the extension.

https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md