### PR TITLE
Fix shortcuts (again)

### DIFF
--- a/extension/src/viewer/components/Toolbar/JQCommandBox.tsx
+++ b/extension/src/viewer/components/Toolbar/JQCommandBox.tsx
@@ -11,6 +11,7 @@ import { Icon, IconButton } from "viewer/components";
 import {
   CHORD_KEY,
   KeydownEvent,
+  isUpperCaseKeypress,
   useGlobalKeydownEvent,
   useReactiveRef,
 } from "viewer/hooks";
@@ -100,7 +101,7 @@ function FilterInput({
   // register global shortcut
   const handleShortcut = useCallback(
     (e: KeydownEvent) => {
-      if (e[CHORD_KEY] && e.key == "F") {
+      if (e[CHORD_KEY] && isUpperCaseKeypress(e, "f")) {
         e.preventDefault();
         current?.focus();
       }

--- a/extension/src/viewer/components/Toolbar/JQCommandBox.tsx
+++ b/extension/src/viewer/components/Toolbar/JQCommandBox.tsx
@@ -101,7 +101,7 @@ function FilterInput({
   // register global shortcut
   const handleShortcut = useCallback(
     (e: KeydownEvent) => {
-      if (e[CHORD_KEY] && isUpperCaseKeypress(e, "f")) {
+      if (e[CHORD_KEY] && isUpperCaseKeypress(e, "F")) {
         e.preventDefault();
         current?.focus();
       }

--- a/extension/src/viewer/components/Toolbar/OpenStateToggle.tsx
+++ b/extension/src/viewer/components/Toolbar/OpenStateToggle.tsx
@@ -22,7 +22,7 @@ export function OpenStateToggle({
       e.preventDefault();
       expand();
     }
-    if (e[CHORD_KEY] && isUpperCaseKeypress(e, "e")) {
+    if (e[CHORD_KEY] && isUpperCaseKeypress(e, "E")) {
       e.preventDefault();
       collapse();
     }

--- a/extension/src/viewer/components/Toolbar/OpenStateToggle.tsx
+++ b/extension/src/viewer/components/Toolbar/OpenStateToggle.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useContext } from "react";
 import { EventType, dispatch } from "viewer/commons/EventBus";
 import { Icon, IconButton } from "viewer/components";
-import { CHORD_KEY, KeydownEvent, useGlobalKeydownEvent } from "viewer/hooks";
+import {
+  CHORD_KEY,
+  KeydownEvent,
+  isUpperCaseKeypress,
+  useGlobalKeydownEvent,
+} from "viewer/hooks";
 import { TranslationContext } from "viewer/localization";
 
 export type OpenStateToggleProps = BaseProps;
@@ -17,7 +22,7 @@ export function OpenStateToggle({
       e.preventDefault();
       expand();
     }
-    if (e[CHORD_KEY] && e.key == "E") {
+    if (e[CHORD_KEY] && isUpperCaseKeypress(e, "e")) {
       e.preventDefault();
       collapse();
     }

--- a/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
+++ b/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
@@ -11,6 +11,7 @@ import {
   CHORD_KEY,
   KeydownBufferEvent,
   KeydownEvent,
+  isUpperCaseKeypress,
   useElementSize,
   useEventBusListener,
   useGlobalKeydownEvent,
@@ -169,13 +170,13 @@ function handleNavigation(
 
   // Page navigation
 
-  if (e.key == "PageDown" || e.key == "J") {
+  if (e.key == "PageDown" || isUpperCaseKeypress(e, "j")) {
     e.preventDefault();
     if (id) treeNavigator.gotoOffset(id, { pages: 1 });
     return;
   }
 
-  if (e.key == "PageUp" || e.key == "K") {
+  if (e.key == "PageUp" || isUpperCaseKeypress(e, "k")) {
     e.preventDefault();
     if (id) treeNavigator.gotoOffset(id, { pages: -1 });
     return;
@@ -187,7 +188,7 @@ function handleNavigation(
     return;
   }
 
-  if (e.key == "End" || e.key == "G") {
+  if (e.key == "End" || isUpperCaseKeypress(e, "g")) {
     e.preventDefault();
     treeNavigator.gotoLast();
     return;

--- a/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
+++ b/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
@@ -170,13 +170,13 @@ function handleNavigation(
 
   // Page navigation
 
-  if (e.key == "PageDown" || isUpperCaseKeypress(e, "j")) {
+  if (e.key == "PageDown" || isUpperCaseKeypress(e, "J")) {
     e.preventDefault();
     if (id) treeNavigator.gotoOffset(id, { pages: 1 });
     return;
   }
 
-  if (e.key == "PageUp" || isUpperCaseKeypress(e, "k")) {
+  if (e.key == "PageUp" || isUpperCaseKeypress(e, "K")) {
     e.preventDefault();
     if (id) treeNavigator.gotoOffset(id, { pages: -1 });
     return;
@@ -188,7 +188,7 @@ function handleNavigation(
     return;
   }
 
-  if (e.key == "End" || isUpperCaseKeypress(e, "g")) {
+  if (e.key == "End" || isUpperCaseKeypress(e, "G")) {
     e.preventDefault();
     treeNavigator.gotoLast();
     return;

--- a/extension/src/viewer/hooks/UseKeydownEvent.ts
+++ b/extension/src/viewer/hooks/UseKeydownEvent.ts
@@ -54,6 +54,15 @@ export function useKeydownBuffer(
   }, [onKeydownBuffer, bufferSize, keypressDelay]);
 }
 
+// performs a double check because one works on windows and one on macos
+// even if I have no idea why (god I hate frontends)
+export function isUpperCaseKeypress(e: KeydownEvent, letter: string): boolean {
+  return (
+    e.key == letter.toUpperCase() ||
+    (e.shiftKey && e.key == letter.toLowerCase())
+  );
+}
+
 export const CHORD_KEY = isMacOs() ? "metaKey" : "ctrlKey";
 
 function isMacOs(): boolean {

--- a/extension/src/viewer/hooks/UseSettings.ts
+++ b/extension/src/viewer/hooks/UseSettings.ts
@@ -26,7 +26,7 @@ export function useSettings(): [Settings, DispatchSettings] {
 
 function maybeUpgrade(settings: Settings): Nullable<Settings> {
   // changes in the same version are backward compatible
-  if (isLatestVersion(settings) && haveMissingKeys(settings)) {
+  if (isLatestVersion(settings) && hasMissingKeys(settings)) {
     return { ...DefaultSettings, ...settings };
   }
 
@@ -40,6 +40,6 @@ function isLatestVersion(settings: Settings): boolean {
   return settings.version == DefaultSettings.version;
 }
 
-function haveMissingKeys(settings: Settings): boolean {
-  return Object.keys(settings).length < Object.keys(DefaultSettings).length;
+function hasMissingKeys(settings: Settings): boolean {
+  return Object.keys(DefaultSettings).some((key: string) => !(key in settings));
 }


### PR DESCRIPTION
For some f***king reason when pressing e.g. the keyword combination `Shift + f`:
- on chrome macos: `e.key == f`
- on chrome windows: `e.key == F` (no need to check for Shift)

Also fix a (possible) bug preventing automatic settings upgrade.