### PR TITLE
Support more IANA json codes

### DIFF
--- a/extension/src/content.tsx
+++ b/extension/src/content.tsx
@@ -7,7 +7,11 @@ if (isJson()) {
 }
 
 function isJson(): boolean {
-  return document.contentType === "application/json";
+  // see: https://www.iana.org/assignments/media-types/media-types.xhtml
+  return (
+    document.contentType.startsWith("application/") &&
+    document.contentType.endsWith("json")
+  );
 }
 
 function afterHeadAvailable(callback: () => void) {


### PR DESCRIPTION
@rvfet review

> [...] For example: rdap.nominet.uk/uk/domain/domain.uk will not be formatted even though the response is json

In fact `document.contentType: 'application/rdap+json'` was not supported. Now the extension should be enabled for all json media types.