### PR TITLE
Add support for JSON Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ built-in search, JQ filtering and many other features... but no strawberries, so
 - [X] JQ filtering
 - [X] Raw JSON viewer
     - [X] Prettify/minify 
+- [X] Support [JSON Lines](https://jsonlines.org/)
 - [X] Download JSON
 - [X] Keyboard shortcuts
 - [X] Appearance
@@ -125,37 +126,11 @@ See also [Issue #15](https://github.com/paolosimone/virtual-json-viewer/issues/1
 
 ### Why this valid JQ command doesn't work?
 
-[JQ](https://stedolan.github.io/jq) commands in Virtual Json Viewer must return valid json, otherwise the parsing of the result will fail with an error e.g.
+[JQ](https://stedolan.github.io/jq) commands in Virtual Json Viewer must return (a list of) valid json, otherwise the parsing of the result will fail with an error e.g.
 
 > Unexpected token { in JSON at position 337
 
 Why? The core feature of Virtual Json Viewer is the navigation of (possibly large) json thanks to virtual DOM that allows on-demand rendering. JQ filtering has been added on top of that, just as handy utilities to further improve the user experience.
-
-_Example_
-
-Let's say we want to extract all the page titles from this [Wikipedia search](https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=pizza&utf8=&format=json).
-
-`.query.search[].title` will fail because a sequence of strings is not a valid json:
-```text
-"Pizza"
-"Hawaiian pizza 😱"
-"History of pizza"
-"Pizza Margherita"
-...
-```
-
-We should use `[.query.search[].title]` instead to obtain a json array:
-```json
-[
-  "Pizza",
-  "Hawaiian pizza 😱",
-  "History of pizza",
-  "Pizza Margherita",
-  ...
-]
-```
-
-ok ok, I added the scream emoji
 
 ### Why the content shown by the extension is different from the actual JSON?
 

--- a/extension/src/content.tsx
+++ b/extension/src/content.tsx
@@ -10,7 +10,8 @@ function isJson(): boolean {
   // see: https://www.iana.org/assignments/media-types/media-types.xhtml
   return (
     document.contentType.startsWith("application/") &&
-    document.contentType.endsWith("json")
+    (document.contentType.endsWith("json") ||
+      document.contentType.endsWith("json-seq"))
   );
 }
 

--- a/extension/src/launcher/ViewerWrapper.tsx
+++ b/extension/src/launcher/ViewerWrapper.tsx
@@ -43,7 +43,12 @@ function JsonPicker({ onFileRead }: JsonPickerProps): JSX.Element {
 
   return (
     <form>
-      <input type="file" accept=".json" multiple={false} onChange={onChange} />
+      <input
+        type="file"
+        accept=".json,.jsonl"
+        multiple={false}
+        onChange={onChange}
+      />
     </form>
   );
 }

--- a/extension/src/viewer/components/Toolbar/SaveButton.tsx
+++ b/extension/src/viewer/components/Toolbar/SaveButton.tsx
@@ -7,15 +7,18 @@ import { TranslationContext } from "viewer/localization";
 import { SettingsContext } from "viewer/state";
 
 export type SaveButtonProps = Props<{
-  json: Json.Root;
+  jsonLines: Json.Lines;
 }>;
 
-export function SaveButton({ json, className }: SaveButtonProps): JSX.Element {
+export function SaveButton({
+  jsonLines,
+  className,
+}: SaveButtonProps): JSX.Element {
   const t = useContext(TranslationContext);
   const { sortKeys, indentation } = useContext(SettingsContext);
   const save = useCallback(
-    () => saveJson(json, { sortKeys, space: indentation }),
-    [json, sortKeys, indentation],
+    () => saveJson(jsonLines, { sortKeys, space: indentation }),
+    [jsonLines, sortKeys, indentation],
   );
 
   // register global shortcut
@@ -43,13 +46,15 @@ export function SaveButton({ json, className }: SaveButtonProps): JSX.Element {
   );
 }
 
-function saveJson(json: Json.Root, opts: Json.ToStringOptions) {
+function saveJson(jsonLines: Json.Lines, opts: Json.ToStringOptions) {
+  const extension = jsonLines.length > 1 ? ".jsonl" : "json";
+
   let filename = document.title;
-  if (!filename.endsWith(".json")) {
-    filename += ".json";
+  if (!filename.endsWith(extension)) {
+    filename += extension;
   }
 
-  const text = Json.toString(json, opts);
+  const text = Json.linesToString(jsonLines, opts);
 
   const element = document.createElement("a");
   element.setAttribute(

--- a/extension/src/viewer/components/Toolbar/Toolbar.tsx
+++ b/extension/src/viewer/components/Toolbar/Toolbar.tsx
@@ -9,14 +9,14 @@ import { SearchBox } from "./SearchBox";
 import { ViewerModeToggle } from "./ViewerModeToggle";
 
 export type ToolbarProps = Props<{
-  json: Json.Root;
+  jsonLines: Json.Lines;
   viewerModeState: StateObject<ViewerMode>;
   searchState: StateObject<Search>;
   jqCommandState?: StateObject<JQCommand>;
 }>;
 
 export function Toolbar({
-  json,
+  jsonLines,
   viewerModeState,
   searchState,
   jqCommandState,
@@ -44,7 +44,7 @@ export function Toolbar({
 
         <Separator />
 
-        <SaveButton className="w-6 h-6 px-px" json={json} />
+        <SaveButton className="w-6 h-6 px-px" jsonLines={jsonLines} />
 
         <SearchBox
           className="flex-1 ml-2"

--- a/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
+++ b/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
@@ -25,15 +25,23 @@ import { JsonNodeData } from "./model/JsonNode";
 import { buildId, getRootNodes, jsonTreeWalker } from "./model/JsonTreeWalker";
 
 export type TreeViewerProps = Props<{
-  json: Json.Root;
+  jsonLines: Json.Lines;
   search: Search;
+  isLargeJson: boolean;
 }>;
 
 export function TreeViewer({
-  json,
+  jsonLines,
   search,
   className,
 }: TreeViewerProps): JSX.Element {
+  // single line -> shown on its own
+  // multiple lines -> shown as an array
+  const json = useMemo(
+    () => (jsonLines.length == 1 ? jsonLines[0] : jsonLines),
+    [jsonLines],
+  );
+
   const { expandNodes } = useContext(SettingsContext);
   const tree = useRef<Tree<JsonNodeData>>(null);
 

--- a/extension/src/viewer/hooks/UseJQ.ts
+++ b/extension/src/viewer/hooks/UseJQ.ts
@@ -5,7 +5,7 @@ import { getURL, JQCommand } from "viewer/state";
 import { Mutex, useEffectAsync, useSettings } from ".";
 
 export type JQEnabled = boolean;
-export type JQResult = Json.Root | Error | undefined;
+export type JQResult = Json.Lines | Error | undefined;
 
 export function useJQ(
   jsonText: string,
@@ -55,8 +55,8 @@ export function useJQ(
 
       try {
         const jq = await loadJQ();
-        const output = await jq.invoke(jsonText, filter);
-        const result = Json.tryParse(output, { sortKeys });
+        const output = await jq.invoke(jsonText, filter, ["--compact-output"]);
+        const result = Json.tryParseLines(output, { sortKeys });
         if (mutex.hasLock()) setResult(result);
       } catch (e) {
         if (mutex.hasLock()) setResult(e as Error);

--- a/extension/src/viewer/hooks/UseRenderedText.ts
+++ b/extension/src/viewer/hooks/UseRenderedText.ts
@@ -1,35 +1,15 @@
-import { ReactNode, useContext, useEffect, useMemo } from "react";
+import { ReactNode, useContext, useMemo } from "react";
 import { RenderedText } from "viewer/components";
 import { Search, SettingsContext } from "viewer/state";
-
-// heuristic: https://media.tenor.com/6PFS7ABeJGEAAAAC/dr-evil-one-billion-dollars.gif
-const LARGE_TEXT_LENGTH = 1_000_000;
 
 export function useRenderedText(
   text: string,
   search: Nullable<Search>,
 ): ReactNode {
-  const { linkifyUrls: linkifySettings } = useContext(SettingsContext);
-
-  // linkifyUrls is disabled for large text to improve performance
-  const isLargeText = text.length > LARGE_TEXT_LENGTH;
-  const linkifyUrls = linkifySettings && !isLargeText;
-
-  useEffect(() => {
-    if (linkifySettings && !linkifyUrls) {
-      console.info(
-        "Large text detected: Linkify URL has been disable to improve performance",
-      );
-    }
-  }, [isLargeText, linkifySettings]);
+  const { linkifyUrls } = useContext(SettingsContext);
 
   return useMemo(
-    () =>
-      RenderedText({
-        text: text,
-        search: search,
-        linkifyUrls: linkifyUrls,
-      }),
+    () => RenderedText({ text, search, linkifyUrls }),
     [text, search, linkifyUrls],
   );
 }

--- a/extension/src/viewer/localization/translations/en.json
+++ b/extension/src/viewer/localization/translations/en.json
@@ -90,7 +90,6 @@
       "clear": "Clear",
       "manual": "JQ Manual",
       "run": "Run command",
-      "syntaxError": "JQ command must return a valid JSON",
       "genericError": "JQ command failed"
     }
   }

--- a/extension/src/viewer/localization/translations/it.json
+++ b/extension/src/viewer/localization/translations/it.json
@@ -90,7 +90,6 @@
       "clear": "Cancella",
       "manual": "Manuale",
       "run": "Esegui il comando",
-      "syntaxError": "Il comando JQ deve restituire un JSON valido",
       "genericError": "Comando JQ fallito"
     }
   }

--- a/samples/json_lines.jsonl
+++ b/samples/json_lines.jsonl
@@ -1,0 +1,3 @@
+{"key": "value_1"}
+{"key": "value_2"}
+{"key": "value_3"}


### PR DESCRIPTION
## What

Adds full support for newline-separated JSON files, i.e. [JSON Lines](https://jsonlines.org/):
- `json-seq` IANA content-type / `.jsonl` file extension
- Tree/Raw visualization
- JQ output
- Download file
- ...

## How

1. At first try to parse the text content as a single JSON (like before)
2. In case of failure try to split the text into lines and parse each one as a separate JSON
3. In both cases a list of JSON is returned and handled by the viewer
4. If the list contains a single JSON the user experience is the same as before
5. If the list contains more than one JSON
    - The tree viewer shows the JSONs like if it was a JSON array
    - The raw viewer shows the JSONs separated by a newline
    - The download button outputs `.jsonl` file extension
    - The raw text is given as input to JQ (which natively supports newline-separated JSONs)

## Why

Mainly because "newline-separated JSON" is the output of many JQ commands: instead of asking the user to adapt the command to output a valid JSON, now the extension will behave as a user would expect.

See #51