### PR TITLE
Check also URL file extension to activate the extension

### DIFF
--- a/extension/src/content.tsx
+++ b/extension/src/content.tsx
@@ -2,7 +2,7 @@ import * as DomEvents from "content/DomEvents";
 import * as Loader from "content/Loader";
 import * as Activator from "content/Activator";
 
-if (Activator.isJsonContentType()) {
+if (Activator.isJson()) {
   DomEvents.afterHeadAvailable(Loader.setupResources);
   DomEvents.afterDocumentLoaded(Loader.loadViewer);
 } else {

--- a/extension/src/content.tsx
+++ b/extension/src/content.tsx
@@ -2,12 +2,12 @@ import * as DomEvents from "content/DomEvents";
 import * as Loader from "content/Loader";
 import * as Activator from "content/Activator";
 
-if (Activator.isJson()) {
+if (Activator.isJsonContentType()) {
   DomEvents.afterHeadAvailable(Loader.setupResources);
   DomEvents.afterDocumentLoaded(Loader.loadViewer);
 } else {
-  Activator.checkSettings()
-    .then((forceActivation) => {
+  Activator.checkActivationSetting()
+    .then((forceActivation: boolean) => {
       if (forceActivation) {
         DomEvents.afterDocumentLoaded(Loader.forceSetupAndLoadViewer);
       }

--- a/extension/src/content/Activator.ts
+++ b/extension/src/content/Activator.ts
@@ -1,13 +1,22 @@
 import { STORAGE } from "viewer/commons/Storage";
 import { Settings, SETTINGS_KEY } from "viewer/state";
 
+export function isJson(): boolean {
+  return isJsonContentType() || isJsonFileExtension();
+}
+
 // see: https://www.iana.org/assignments/media-types/media-types.xhtml
-export function isJsonContentType(): boolean {
+function isJsonContentType(): boolean {
   return (
     document.contentType.startsWith("application/") &&
     (document.contentType.endsWith("json") ||
       document.contentType.endsWith("json-seq"))
   );
+}
+
+function isJsonFileExtension(): boolean {
+  const path = window.location.pathname;
+  return path.endsWith(".json") || path.endsWith(".jsonl");
 }
 
 export async function checkSettings(): Promise<boolean> {

--- a/extension/src/content/Activator.ts
+++ b/extension/src/content/Activator.ts
@@ -1,12 +1,8 @@
 import { STORAGE } from "viewer/commons/Storage";
 import { Settings, SETTINGS_KEY } from "viewer/state";
 
-export function isJson(): boolean {
-  return isJsonContentType() || isJsonFileExtension();
-}
-
 // see: https://www.iana.org/assignments/media-types/media-types.xhtml
-function isJsonContentType(): boolean {
+export function isJsonContentType(): boolean {
   return (
     document.contentType.startsWith("application/") &&
     (document.contentType.endsWith("json") ||
@@ -14,12 +10,7 @@ function isJsonContentType(): boolean {
   );
 }
 
-function isJsonFileExtension(): boolean {
-  const path = window.location.pathname;
-  return path.endsWith(".json") || path.endsWith(".jsonl");
-}
-
-export async function checkSettings(): Promise<boolean> {
+export async function checkActivationSetting(): Promise<boolean> {
   const settings = await STORAGE.get<Settings>(SETTINGS_KEY);
   const activationUrlRegex = settings?.activationUrlRegex || null;
 
@@ -27,10 +18,7 @@ export async function checkSettings(): Promise<boolean> {
     return false;
   }
 
-  if (activationUrlRegex === ".*") {
-    return true;
-  }
-
-  const regex = new RegExp(activationUrlRegex);
-  return regex.test(location.href);
+  const activationRegex = new RegExp(activationUrlRegex);
+  const url = location.origin + location.pathname;
+  return activationRegex.test(url);
 }

--- a/extension/src/content/Loader.tsx
+++ b/extension/src/content/Loader.tsx
@@ -22,7 +22,7 @@ export function forceSetupAndLoadViewer() {
   const jsonText = tryFindJsonText();
   if (!jsonText) {
     console.warn(
-      "Virtual Json Viewer forceful activation failed: JSON not found",
+      "Virtual Json Viewer activation failed: JSON expected but not found",
     );
     return;
   }

--- a/extension/src/options/components/ForceActivationSelect.tsx
+++ b/extension/src/options/components/ForceActivationSelect.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { Icon, IconLabel, Select } from "viewer/components";
+import { DefaultSettings } from "viewer/state";
 
 export type ForceActivationSelectProps = Props<{
   urlRegex: Nullable<string>;
@@ -54,7 +55,7 @@ function regexToOption(urlRegex: Nullable<string>): Option {
 }
 
 function optionToDefaultRegex(option: Option): Nullable<string> {
-  return option === "custom" ? ".*" : null;
+  return option === "custom" ? DefaultSettings.activationUrlRegex : null;
 }
 
 type UrlRegexInputProps = Props<{

--- a/extension/src/viewer/commons/Storage.ts
+++ b/extension/src/viewer/commons/Storage.ts
@@ -9,11 +9,11 @@ export interface Storage {
   addListener<T>(key: string, onChange: OnItemChange<T>): RemoveListener;
 }
 
-class LocalStorage implements Storage {
+class SessionStorage implements Storage {
   get<T>(key: string): Promise<Nullable<T>> {
     return new Promise((resolve, reject) => {
       try {
-        const value = localStorage.getItem(key);
+        const value = sessionStorage.getItem(key);
         resolve(value !== null ? JSON.parse(value) : null);
       } catch (e) {
         reject(e);
@@ -24,7 +24,7 @@ class LocalStorage implements Storage {
   set<T>(key: string, item: T): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
-        localStorage.setItem(key, JSON.stringify(item));
+        sessionStorage.setItem(key, JSON.stringify(item));
         resolve();
       } catch (e) {
         reject(e);
@@ -79,4 +79,4 @@ class SyncStorage implements Storage {
 }
 
 export const STORAGE =
-  RUNTIME === Runtime.Extension ? new SyncStorage() : new LocalStorage();
+  RUNTIME === Runtime.Extension ? new SyncStorage() : new SessionStorage();

--- a/extension/src/viewer/state/Settings.ts
+++ b/extension/src/viewer/state/Settings.ts
@@ -44,9 +44,10 @@ const textSizeClasses: Record<TextSize, string> = {
 /* Context */
 
 export const DefaultSettings: Settings = {
-  version: 1,
+  version: 2,
 
-  activationUrlRegex: null,
+  // all URL paths ending with a json file extension
+  activationUrlRegex: "^.*(\\.jsonl?)$",
   enableJQ: true,
   expandNodes: false,
   indentation: 4,


### PR DESCRIPTION
### Context

The extensions checks the content type to decide whether to activate, but there are cases in which the content type is wrongly set, e.g. when opening `.json` in `raw.githubusercontent.com` or `.jsonl` local files in Chrome it's set to to `Content-Type: text/plain`.

### Change

Leveraging "force activation" functionality introduced in https://github.com/paolosimone/virtual-json-viewer/pull/54 now the default fallback behavior is to check the URL file extension to be either `.json` or `.jsonl`. 

Note that the check is performed as fallback and it can gracefully fail, since there is no guarantee that a URL ending with `.json` actually contains **only** the JSON, e.g. `https://github.com/paolosimone/virtual-json-viewer/blob/master/samples/test.json` shows Github's web page.

Being an opinionated fallback, the user can opt-out by simply disabling the *"Force extension activation"* setting.

The setting will be upgraded the first time the extension UI is loaded. If the user already set a custom URL regex it won't be overwritten.

---

⚠️ **POSSIBLY BREAKING CHANGE**

The custom URL regex is now checked against  `location.origin + location.pathname` instead of `location.href`, i.e. excluding query parameters. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location).