### PR TITLE
Fix viewer overflow when showing an error banner

### DIFF
--- a/extension/src/viewer/App.tsx
+++ b/extension/src/viewer/App.tsx
@@ -127,7 +127,8 @@ export function App({ jsonText }: AppProps): JSX.Element {
           <Viewer
             {...viewerProps}
             className={classNames(
-              "flex-auto pt-1.5 pl-1.5 text-viewer-foreground selection:bg-amber-200 selection:text-black",
+              // min-h-0 prevents overflow when showing an error banner (https://stackoverflow.com/a/66689926)
+              "flex-auto min-h-0 pt-1.5 pl-1.5 text-viewer-foreground selection:bg-amber-200 selection:text-black",
               resolveTextSizeClass(settings.textSize),
             )}
           />


### PR DESCRIPTION
As per title, prevents viewer div to overflow outside the viewscreen when showing an error banner (e.g. JQ syntax error). 
Now the div it's correctly resized by the flex container.

Related to https://github.com/paolosimone/virtual-json-viewer/issues/32 and https://github.com/paolosimone/virtual-json-viewer/issues/56 

_I hate CSS_