### PR TITLE
Fix select all shortcut in toolbar's input

### DIFF
--- a/extension/src/viewer/App.tsx
+++ b/extension/src/viewer/App.tsx
@@ -10,6 +10,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { isActiveElementEditable } from "./commons/Dom";
 import {
   Alert,
   RawViewer,
@@ -74,13 +75,14 @@ export function App({ jsonText }: AppProps): JSX.Element {
 
   const viewerProps = useTransitionViewerProps(state, jsonText, jsonLines);
 
-  // disable "select all" shortcut
-  const handleNavigation = useCallback((e: KeydownEvent) => {
-    if (e[CHORD_KEY] && e.key === "a") {
+  // browser default's "select all" behavior is not meaningful in the viewer,
+  // children components should handle their own selection (except for standard input elements)
+  const disableSelectAll = useCallback((e: KeydownEvent) => {
+    if (e[CHORD_KEY] && e.key === "a" && !isActiveElementEditable()) {
       e.preventDefault();
     }
   }, []);
-  useGlobalKeydownEvent(handleNavigation);
+  useGlobalKeydownEvent(disableSelectAll);
 
   // -- no hooks below -- //
 

--- a/extension/src/viewer/commons/Dom.ts
+++ b/extension/src/viewer/commons/Dom.ts
@@ -11,3 +11,16 @@ export function selectAllText(elem: HTMLElement) {
 export function deselectAllText() {
   window.getSelection()?.removeAllRanges();
 }
+
+export function isActiveElementEditable(): boolean {
+  const activeElement = document.activeElement;
+  if (!activeElement) return false;
+
+  const tagName = activeElement.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea") {
+    return true;
+  }
+
+  const contentEditable = activeElement.getAttribute("contenteditable");
+  return contentEditable === "true" || contentEditable === "";
+}

--- a/extension/src/viewer/components/Toolbar/SearchBox.tsx
+++ b/extension/src/viewer/components/Toolbar/SearchBox.tsx
@@ -1,3 +1,4 @@
+import { isActiveElementEditable } from "@/viewer/commons/Dom";
 import { Icon, IconButton, IconLabel } from "@/viewer/components";
 import {
   CHORD_KEY,
@@ -158,11 +159,10 @@ function SearchInput({
   // override browser search shortcut
   const handleShortcut = useCallback(
     (e: KeydownEvent) => {
-      if (document.activeElement === current) {
-        return;
-      }
-
-      if ((e[CHORD_KEY] && e.key === "f") || e.key === "/") {
+      if (
+        (e[CHORD_KEY] && e.key === "f") ||
+        (e.key === "/" && !isActiveElementEditable())
+      ) {
         e.preventDefault();
         current?.focus();
       }


### PR DESCRIPTION
Fixes bug report #71 by restoring browser default behavior if the current active element is editable (i.e. in our case an `input`).

It also fixes another  bug that prevented the forward slash character to be typed in the JQ toolbar, since it was wrongly considered a shortcut.

