### PR TITLE
Search index optimization

### DIFF
--- a/extension/src/viewer/components/TreeViewer/Tree/NodeState.ts
+++ b/extension/src/viewer/components/TreeViewer/Tree/NodeState.ts
@@ -2,10 +2,14 @@ import * as Json from "@/viewer/commons/Json";
 import { SearchMatch } from "../TreeWalker";
 export type { SearchMatch } from "../TreeWalker";
 
-export type NodeId = string;
+// strictly positive integer (to avoid 0 which is falsy)
+export type NodeId = number;
+
+export type NodeWalkId = string;
 
 export type NodeState = {
   id: NodeId;
+  walkId: NodeWalkId;
   key: Nullable<Json.Key>;
   value: Json.Root;
   nesting: number;

--- a/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
+++ b/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
@@ -95,7 +95,6 @@ export class TreeNavigator {
     }
   }
 
-  // O(N)
   goto(id: NodeId) {
     // manually mark the node as focused, because
     // the target html element could be outside the virtual list


### PR DESCRIPTION
Replaced the `indexById` method's linear search (`O(N)`) with a binary search algorithm (`O(log(N)`) for faster lookups in the `visibleNodes` array. 

NodeState's id is now an incremental number that reflects the global ordering in the tree walk.

Human-readable string id could still be useful for debugging and it has been kept as a `walkId` field.