### PR TITLE
Store walked nodes as list

### DIFF
--- a/extension/src/viewer/components/TreeViewer/Tree/NodeState.ts
+++ b/extension/src/viewer/components/TreeViewer/Tree/NodeState.ts
@@ -2,7 +2,6 @@ import * as Json from "@/viewer/commons/Json";
 import { SearchMatch } from "../TreeWalker";
 export type { SearchMatch } from "../TreeWalker";
 
-// strictly positive integer (to avoid 0 which is falsy)
 export type NodeId = number;
 
 export type NodeWalkId = string;

--- a/extension/src/viewer/components/TreeViewer/Tree/TreeHandler.ts
+++ b/extension/src/viewer/components/TreeViewer/Tree/TreeHandler.ts
@@ -37,6 +37,10 @@ export class TreeHandler {
     return this.tree.nodeById(id);
   }
 
+  public iterAll(): Generator<NodeState> {
+    return this.tree.iterAll();
+  }
+
   // Openness
 
   public isOpen(id: NodeId): boolean {

--- a/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
+++ b/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
@@ -62,13 +62,13 @@ export class TreeNavigator {
 
     // if already closed and it has a parent, then close the parent
     const parentId = this.tree?.get(id).parent?.id;
-    if (parentId) {
+    if (parentId !== undefined) {
       this.goto(parentId);
       this.close(parentId);
     }
   }
 
-  gotoOffset(id: NodeId, { rows, pages }: NavigationOffset) {
+  public gotoOffset(id: NodeId, { rows, pages }: NavigationOffset) {
     const index = this.tree?.indexById(id);
     if (index !== undefined) {
       const target = index + (rows ?? 0) + (pages ?? 0) * this.pageRows();
@@ -76,17 +76,17 @@ export class TreeNavigator {
     }
   }
 
-  gotoFirst() {
+  public gotoFirst() {
     this.gotoIndex(0);
   }
 
-  gotoLast() {
+  public gotoLast() {
     if (!this.tree?.length()) return;
     this.gotoIndex(this.tree.length() - 1);
   }
 
-  getCurrentId(): NodeId | undefined {
-    if (this.lastFocused) {
+  public getCurrentId(): NodeId | undefined {
+    if (this.lastFocused !== undefined) {
       return this.lastFocused;
     }
 
@@ -95,7 +95,7 @@ export class TreeNavigator {
     }
   }
 
-  goto(id: NodeId) {
+  public goto(id: NodeId) {
     // manually mark the node as focused, because
     // the target html element could be outside the virtual list
     this.lastFocused = id;

--- a/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
+++ b/extension/src/viewer/components/TreeViewer/TreeViewer.tsx
@@ -1,4 +1,5 @@
 import * as DOM from "@/viewer/commons/Dom";
+import { EventType } from "@/viewer/commons/EventBus";
 import * as Json from "@/viewer/commons/Json";
 import {
   CHORD_KEY,
@@ -14,9 +15,7 @@ import {
 import { Search, SettingsContext } from "@/viewer/state";
 import classNames from "classnames";
 import { JSX, useCallback, useContext, useMemo } from "react";
-// import { TreeNavigator } from "./TreeNavigator";
-import { EventType } from "@/viewer/commons/EventBus";
-import { Tree, TreeHandler } from "./Tree";
+import { NodeId, Tree, TreeHandler } from "./Tree";
 import { TreeNavigator } from "./TreeNavigator";
 import { TreeNode } from "./TreeNode";
 import { treeWalker } from "./TreeWalker";
@@ -119,13 +118,16 @@ function handleNavigation(
   tree: TreeNavigator,
   { last: e, text }: KeydownBufferEvent,
 ) {
-  const id = tree.getCurrentId();
+  function from(navigate: (id: NodeId) => void) {
+    const id = tree.getCurrentId();
+    if (id !== undefined) navigate(id);
+  }
 
   // Focus
 
   if (e.key == "Enter") {
     e.preventDefault();
-    if (id) tree.goto(id);
+    from((id) => tree.goto(id));
     return;
   }
 
@@ -140,13 +142,13 @@ function handleNavigation(
 
   if (e.key == "ArrowDown" || e.key == "j") {
     e.preventDefault();
-    if (id) tree.gotoOffset(id, { rows: 1 });
+    from((id) => tree.gotoOffset(id, { rows: 1 }));
     return;
   }
 
   if (e.key == "ArrowUp" || e.key == "k") {
     e.preventDefault();
-    if (id) tree.gotoOffset(id, { rows: -1 });
+    from((id) => tree.gotoOffset(id, { rows: -1 }));
     return;
   }
 
@@ -154,13 +156,13 @@ function handleNavigation(
 
   if (e.key == "PageDown" || isUpperCaseKeypress(e, "J")) {
     e.preventDefault();
-    if (id) tree.gotoOffset(id, { pages: 1 });
+    from((id) => tree.gotoOffset(id, { pages: 1 }));
     return;
   }
 
   if (e.key == "PageUp" || isUpperCaseKeypress(e, "K")) {
     e.preventDefault();
-    if (id) tree.gotoOffset(id, { pages: -1 });
+    from((id) => tree.gotoOffset(id, { pages: -1 }));
     return;
   }
 
@@ -180,19 +182,19 @@ function handleNavigation(
 
   if (e.key == "ArrowRight" || e.key == "l") {
     e.preventDefault();
-    if (id) tree.open(id);
+    from((id) => tree.open(id));
     return;
   }
 
   if (e.key == "ArrowLeft" || e.key == "h") {
     e.preventDefault();
-    if (id) tree.close(id);
+    from((id) => tree.close(id));
     return;
   }
 
   if (e.key == " ") {
     e.preventDefault();
-    if (id) tree.toggleOpen(id);
+    from((id) => tree.toggleOpen(id));
     return;
   }
 }


### PR DESCRIPTION
Replaced `nodesById` (a `Map`) with a `nodes` array in `TreeState` for storing nodes, improving performance and simplifying access patterns. 