### PR TITLE
Search match navigation - Tree Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Rightful question, and the answer is quite simple: the others weren't good enoug
     - [X] Option to sort JSON keys alphabetically
 - [X] Full text search
     - [X] Highlight search results
-    - [ ] Navigate to next/previous search match
+    - [X] Navigate to next/previous search match
     - [X] Option to completely hide subtrees without any search match
     - [X] Option to enable case sensitive search
 - [X] JQ filtering

--- a/extension/src/viewer/commons/Json.ts
+++ b/extension/src/viewer/commons/Json.ts
@@ -25,12 +25,6 @@ import stableStringify from "json-stable-stringify";
  * Javascript also offers a Map type that seems to fit our use case, why not use it?
  * The drawback of building a Map on JSON.parse would be to convert it back
  * to an object on serialization, since JSON.stringify works only with objects.
- * In our use case JSON.parse is called rarely (on first load and when running JQ filtering),
- * while JSON.stringify could be called a lot of times, since it's the core routine of
- * the search functionality.
- *
- * Anyway, the data structure used as object is an internal detail of this module
- * and could be easily swapped whithout too much impact on the rest of the codebase.
  *
  * __Stringify__
  *

--- a/extension/src/viewer/components/RenderedText/SearchedText.tsx
+++ b/extension/src/viewer/components/RenderedText/SearchedText.tsx
@@ -32,7 +32,13 @@ export function SearchedText({
     ref,
     () => ({
       setSelected,
-      scrollIntoView: () => markRef.current?.scrollIntoView(),
+      scrollIntoView: () =>
+        markRef.current?.scrollIntoView({
+          // Vertical: center the match in the viewport
+          block: "center",
+          // Horizontal: show as much text on the left as possible
+          inline: "end",
+        }),
     }),
     [setSelected, markRef],
   );

--- a/extension/src/viewer/components/Toolbar/SearchBox/SearchBox.tsx
+++ b/extension/src/viewer/components/Toolbar/SearchBox/SearchBox.tsx
@@ -44,8 +44,7 @@ export function SearchBox({
         setText={(text) => updateSearch({ text })}
       />
 
-      {/* TODO search navigation for tree viewer */}
-      {!enableVisibility && search.text && (
+      {search.text && (
         <SearchNavigationPanel
           className="mx-3 h-6"
           currentIndex={navigation.currentIndex}

--- a/extension/src/viewer/components/TreeViewer/Tree/TreeHandler.ts
+++ b/extension/src/viewer/components/TreeViewer/Tree/TreeHandler.ts
@@ -1,5 +1,5 @@
 import { RefCurrent } from "@/viewer/hooks";
-import { VariableSizeList } from "react-window";
+import { Align, VariableSizeList } from "react-window";
 import { NodeId, NodeState } from "./NodeState";
 import { ItemData } from "./TreeItem";
 import { TreeState } from "./TreeState";
@@ -73,8 +73,8 @@ export class TreeHandler {
 
   // Navigation
 
-  public scrollTo(id: NodeId) {
+  public scrollTo(id: NodeId, align?: Align) {
     const index = this.tree.indexById(id);
-    this.list?.scrollToItem(index);
+    this.list?.scrollToItem(index, align);
   }
 }

--- a/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
+++ b/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
@@ -1,4 +1,6 @@
+import { SearchMatchHandler } from "@/viewer/components/RenderedText";
 import { RefCurrent } from "@/viewer/hooks";
+import { SearchNavigation } from "@/viewer/state";
 import { NodeId, TreeHandler } from "./Tree";
 
 export type NavigationOffset = {
@@ -6,13 +8,41 @@ export type NavigationOffset = {
   pages?: number;
 };
 
+export enum NodePart {
+  Key = "key",
+  Value = "value",
+}
+
+export interface TreeNavigatorNodeHandler {
+  focus(): void;
+  blur(): void;
+  registerOnFocus(callback: () => void): void;
+  getMatchHandler(
+    part: NodePart,
+    index: number,
+  ): SearchMatchHandler | undefined;
+}
+
+export type SearchNavigationCallback = (navigation: SearchNavigation) => void;
+
+type FlattenedSearchMatch = {
+  nodeId: NodeId;
+  nodePart: NodePart;
+  index: number;
+};
+
 export class TreeNavigator {
   private tree: RefCurrent<TreeHandler>;
   private treeElem: RefCurrent<HTMLElement>;
 
   // Nodes navigation
-  private elemById: Map<NodeId, HTMLElement> = new Map();
+  private handlerById: Map<NodeId, TreeNavigatorNodeHandler> = new Map();
   private lastFocused?: NodeId;
+
+  // Search navigation
+  private searchMatches: FlattenedSearchMatch[] = [];
+  private searchIndex: Nullable<number> = null;
+  private onSearchNavigation?: SearchNavigationCallback;
 
   constructor(
     tree: RefCurrent<TreeHandler>,
@@ -24,24 +54,30 @@ export class TreeNavigator {
 
   // Nodes lifecycle
 
-  public onElemShown(id: NodeId, elem: HTMLElement) {
-    this.elemById.set(id, elem);
+  public onNodeShown(id: NodeId, handler: TreeNavigatorNodeHandler) {
+    this.handlerById.set(id, handler);
 
-    // register to external focus event (e.g. by mouse click)
-    elem.onfocus = () => (this.lastFocused = id);
+    // Register to external focus event (e.g. by mouse click)
+    handler.registerOnFocus(() => (this.lastFocused = id));
 
-    // handle pending navigation
+    // Handle pending navigation
     if (id === this.lastFocused) {
-      elem.focus();
+      this.tryFocusCurrent();
+    }
+
+    // Handle previous search match selection
+    const searchNodeId = this.searchMatches[this.searchIndex ?? -1]?.nodeId;
+    if (id === searchNodeId) {
+      this.trySelectCurrentSearchMatch();
     }
   }
 
-  public onElemHidden(id: NodeId) {
-    this.elemById.delete(id);
+  public onNodeHidden(id: NodeId) {
+    this.handlerById.delete(id);
 
     // return focus to parent to avoid inconsistencies
     if (id === this.lastFocused) {
-      this.lastFocused = undefined;
+      this.tryBlurCurrent();
       this.treeElem?.focus();
     }
   }
@@ -109,7 +145,18 @@ export class TreeNavigator {
     this.lastFocused = id;
 
     this.tree?.scrollTo(id);
-    this.elemById.get(id)?.focus();
+    this.tryFocusCurrent();
+  }
+
+  private tryFocusCurrent() {
+    if (this.lastFocused === undefined) return;
+    this.handlerById.get(this.lastFocused)?.focus();
+  }
+
+  private tryBlurCurrent() {
+    if (this.lastFocused === undefined) return;
+    this.handlerById.get(this.lastFocused)?.blur();
+    this.lastFocused = undefined;
   }
 
   private gotoIndex(index: number) {
@@ -126,5 +173,97 @@ export class TreeNavigator {
     return pageHeight && itemHeight ? Math.ceil(pageHeight / itemHeight) : 1;
   }
 
-  // TODO Search navigation
+  // Search navigation
+
+  public enableSearchNavigation(callback: SearchNavigationCallback) {
+    if (!this.tree) return;
+    this.onSearchNavigation = callback;
+    this.searchMatches = flattenSearchMatches(this.tree);
+
+    if (this.searchMatches.length) {
+      this.goToSearchIndex(0);
+    } else {
+      this.notifySearchNavigation();
+    }
+  }
+
+  public goToPreviousSearchMatch() {
+    if (!this.searchMatches.length) return;
+    const previous = (this.searchIndex || this.searchMatches.length) - 1;
+    this.goToSearchIndex(previous);
+  }
+
+  public goToNextSearchMatch() {
+    if (!this.searchMatches.length) return;
+    const next = ((this.searchIndex ?? -1) + 1) % this.searchMatches.length;
+    this.goToSearchIndex(next);
+  }
+
+  private goToSearchIndex(index: number) {
+    // Deselect previous match
+    if (this.searchIndex !== null) {
+      this.getSearchHandler(this.searchIndex)?.setSelected(false);
+    }
+
+    // Update current index
+    this.searchIndex = index;
+
+    // Blur the current node if it was focused
+    this.tryBlurCurrent();
+
+    // Go to the next node
+    const nodeId = this.searchMatches[index]!.nodeId;
+    this.tree?.scrollTo(nodeId);
+
+    // Select the match inside the node
+    this.trySelectCurrentSearchMatch();
+
+    // Notify the change
+    this.notifySearchNavigation();
+  }
+
+  private trySelectCurrentSearchMatch() {
+    if (this.searchIndex === null) return;
+    const handler = this.getSearchHandler(this.searchIndex);
+    handler?.setSelected(true);
+  }
+
+  private getSearchHandler(index: number): SearchMatchHandler | undefined {
+    const match = this.searchMatches[index];
+    if (!match) return undefined;
+    return this.handlerById
+      .get(match.nodeId)
+      ?.getMatchHandler(match.nodePart, match.index);
+  }
+
+  private notifySearchNavigation() {
+    if (this.onSearchNavigation) {
+      this.onSearchNavigation({
+        currentIndex: this.searchIndex,
+        totalCount: this.searchMatches.length,
+      });
+    }
+  }
+}
+
+function flattenSearchMatches(tree: TreeHandler): FlattenedSearchMatch[] {
+  return tree
+    .iterAll()
+    .flatMap((node) => {
+      if (!node.searchMatch) return [];
+
+      return [
+        ...node.searchMatch.keyMatches.map((_match, index) => ({
+          nodeId: node.id,
+          nodePart: NodePart.Key,
+          index,
+        })),
+        ...node.searchMatch.valueMatches.map((_match, index) => ({
+          nodeId: node.id,
+          nodePart: NodePart.Value,
+          index,
+        })),
+      ];
+    })
+    .toArray();
 }

--- a/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
+++ b/extension/src/viewer/components/TreeViewer/TreeNavigator.ts
@@ -213,7 +213,7 @@ export class TreeNavigator {
 
     // Go to the next node
     const nodeId = this.searchMatches[index]!.nodeId;
-    this.tree?.scrollTo(nodeId);
+    this.tree?.scrollTo(nodeId, "center");
 
     // Select the match inside the node
     this.trySelectCurrentSearchMatch();

--- a/extension/src/viewer/components/TreeViewer/TreeNode/RenderedTextFromSearch.tsx
+++ b/extension/src/viewer/components/TreeViewer/TreeNode/RenderedTextFromSearch.tsx
@@ -8,6 +8,11 @@ import {
 import { SettingsContext } from "@/viewer/state";
 import { ReactNode, Ref, useContext, useMemo } from "react";
 
+export type {
+  RenderedTextRef,
+  SearchMatchHandler,
+} from "@/viewer/components/RenderedText";
+
 export type RenderedTextFromSearchProps = Props<{
   text: string;
   searchMatches: SearchMatchRange[];

--- a/extension/src/viewer/components/TreeViewer/TreeNode/Value.tsx
+++ b/extension/src/viewer/components/TreeViewer/TreeNode/Value.tsx
@@ -4,10 +4,15 @@ import { SearchMatchRange } from "@/viewer/commons/Searcher";
 import classNames from "classnames";
 import { JSX, Ref, useImperativeHandle, useRef } from "react";
 import { NodeState } from "../Tree";
-import { RenderedTextFromSearch } from "./RenderedTextFromSearch";
+import {
+  RenderedTextFromSearch,
+  RenderedTextRef,
+  SearchMatchHandler,
+} from "./RenderedTextFromSearch";
 
 export type ValueHandle = {
   selectText: () => void;
+  getMatchHandler: (index: number) => SearchMatchHandler | undefined;
 };
 
 export type ValueProps = Props<{
@@ -78,16 +83,20 @@ export function LiteralValue({
   className,
   ref,
 }: LiteralValueProps): JSX.Element {
-  const valueRef = useRef<HTMLSpanElement>(null);
+  const outerRef = useRef<HTMLSpanElement>(null);
+  const textRef = useRef<RenderedTextRef>(null);
 
   useImperativeHandle(
     ref,
     () => ({
       selectText() {
-        if (valueRef.current) DOM.selectAllText(valueRef.current);
+        if (outerRef.current) DOM.selectAllText(outerRef.current);
+      },
+      getMatchHandler(index: number): SearchMatchHandler | undefined {
+        return textRef.current?.searchMatches[index];
       },
     }),
-    [valueRef],
+    [outerRef, textRef],
   );
 
   const isString = Json.isString(value);
@@ -98,8 +107,9 @@ export function LiteralValue({
   return (
     <span className={classNames("whitespace-pre-wrap", textColor, className)}>
       {isString && <span>&quot;</span>}
-      <span ref={valueRef}>
+      <span ref={outerRef}>
         <RenderedTextFromSearch
+          ref={textRef}
           text={textValue}
           searchMatches={searchMatches}
         />


### PR DESCRIPTION
Handle navigation through search matches in Tree Viewer:
- When searching, the viewer scrolls automatically to the first match (if present)
- Navigating through matches scroll the appropriate node into view
- Node navigation and search matches navigation are mutually exclusive

**Demo**

https://github.com/user-attachments/assets/f1f3adf6-b478-474a-a16e-592511230b24

---

Note: Raw Viewer search matches navigation was introduced in #84 