### PR TITLE
Set default search visibility to all nodes

### DIFF
--- a/extension/src/viewer/state/Search.ts
+++ b/extension/src/viewer/state/Search.ts
@@ -12,7 +12,7 @@ export enum SearchVisibility {
 
 export const EmptySearch: Search = {
   text: "",
-  visibility: SearchVisibility.Subtree,
+  visibility: SearchVisibility.All,
   caseSensitive: false,
 };
 


### PR DESCRIPTION
Now that the extension supports navigation between search matches, there is no need to hide unmatched subtrees by default.

This only affects new installs: existing users will keep using the option stored in their configuration.