### PR TITLE
Support jsonl Media Type

### DIFF
--- a/extension/src/content/Activator.ts
+++ b/extension/src/content/Activator.ts
@@ -1,12 +1,21 @@
 import { STORAGE } from "@/viewer/commons/Storage";
 import { Settings, SETTINGS_KEY } from "@/viewer/state";
 
-// see: https://www.iana.org/assignments/media-types/media-types.xhtml
+const MIME_TYPE_JSON_SUFFIXES = [
+  // Official: https://www.iana.org/assignments/media-types/media-types.xhtml
+  "json",
+  "json-seq",
+  // Candidates: https://github.com/wardi/jsonlines/issues/19
+  "jsonl",
+  "jsonlines",
+];
+
 export function isJsonContentType(): boolean {
   return (
     document.contentType.startsWith("application/") &&
-    (document.contentType.endsWith("json") ||
-      document.contentType.endsWith("json-seq"))
+    MIME_TYPE_JSON_SUFFIXES.some((suffix) =>
+      document.contentType.endsWith(suffix),
+    )
   );
 }
 


### PR DESCRIPTION
Activate the application on `jsonl` candidate MIME type.

Some other commonly used types are supported as well (`jsonlines`, `ndjson`, ...)

References:
- https://github.com/wardi/jsonlines/issues/19
- https://github.com/wardi/jsonlines/pull/96
- [jsonlines.org](https://jsonlines.org/)