### PR TITLE
Do not reuse JQ runtime

### DIFF
--- a/extension/src/viewer/hooks/UseJQ.ts
+++ b/extension/src/viewer/hooks/UseJQ.ts
@@ -3,7 +3,7 @@ import * as Json from "@/viewer/commons/Json";
 import { getURL } from "@/viewer/commons/Runtime";
 import { DefaultSettings, JQCommand, useSettings } from "@/viewer/state";
 import { useState } from "react";
-import { Mutex, useEffectAsync, useReactiveRef } from ".";
+import { Mutex, useEffectAsync } from ".";
 
 export type JQEnabled = boolean;
 export type JQResult = Json.Lines | Error | undefined;
@@ -17,26 +17,26 @@ export function useJQ(
   const { enableJQ, sortKeys } = settings ?? DefaultSettings;
 
   // check if wasm is enabled on first load
-  const [jq, setJQ] = useReactiveRef<JQ>();
+  const [jqEnabled, setJQEnabled] = useState<boolean>(true);
 
   useEffectAsync(
     async (mutex: Mutex) => {
       if (!enableJQ && mutex.hasLock()) {
-        setJQ(null);
+        setJQEnabled(false);
         return;
       }
 
       try {
-        const jqCurrent = await loadJQ();
+        await loadJQ();
         if (mutex.hasLock()) {
-          setJQ(jqCurrent);
+          setJQEnabled(true);
         }
       } catch {
         if (mutex.hasLock()) {
           console.warn(
             "Unable to load JQ, Wasm is probably disabled due to CSP. For additional info: https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md",
           );
-          setJQ(null);
+          setJQEnabled(false);
         }
       }
     },
@@ -52,31 +52,31 @@ export function useJQ(
         return;
       }
 
-      if (!jq || !command.filter) {
+      if (!jqEnabled || !command.filter) {
         setResult(undefined);
         return;
       }
 
       try {
-        const result = await invokeJQ(jq, jsonText, command, sortKeys);
+        const result = await invokeJQ(jsonText, command, sortKeys);
         if (mutex.hasLock()) setResult(result);
       } catch (e) {
         if (mutex.hasLock()) setResult(e as Error);
       }
     },
-    [jq, jsonText, command, sortKeys],
+    [jqEnabled, jsonText, command, sortKeys],
   );
 
-  const jqEnabled = jq !== null;
   return [jqEnabled, result];
 }
 
 async function invokeJQ(
-  jq: JQ,
   jsonText: string,
   command: JQCommand,
   sortKeys: boolean,
 ): Promise<JQResult> {
+  const jq = await loadJQ();
+
   // One JSON per line in output
   const options = ["--compact-output"];
   // Whole input text as array, if multiline
@@ -92,7 +92,8 @@ function loadJQ(): Promise<JQ> {
     locateFile: () => getURL("assets/jq.wasm"),
     print: devNull,
     printErr: devNull,
-    noExitRuntime: true,
+    // Clean up the runtime between calls
+    noExitRuntime: false,
   });
 }
 

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -18,7 +18,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["chrome"],
+    "types": ["chrome"]
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
I recently encountered some weird errors when running multiple JQ commands on large-ish json.

Let's defensively revert #95 by spawning a new jq instance every time a command is invoked.

